### PR TITLE
fix build error

### DIFF
--- a/drivers/infiniband/core/cache.c
+++ b/drivers/infiniband/core/cache.c
@@ -199,8 +199,8 @@ static void ib_cache_update(struct ib_device *device,
 			    u8                port)
 {
 	struct ib_port_attr       *tprops = NULL;
-	struct ib_pkey_cache      *pkey_cache = NULL, *old_pkey_cache;
-	struct ib_gid_cache       *gid_cache = NULL, *old_gid_cache;
+	struct ib_pkey_cache      *pkey_cache = NULL, *old_pkey_cache = NULL;
+	struct ib_gid_cache       *gid_cache = NULL, *old_gid_cache = NULL;
 	int                        i;
 	int                        ret;
 

--- a/drivers/infiniband/core/cm.c
+++ b/drivers/infiniband/core/cm.c
@@ -2289,7 +2289,7 @@ static void cm_format_rej_event(struct cm_work *work)
 static struct cm_id_private * cm_acquire_rejected_id(struct cm_rej_msg *rej_msg)
 {
 	struct cm_timewait_info *timewait_info;
-	struct cm_id_private *cm_id_priv;
+	struct cm_id_private *cm_id_priv = NULL;
 	__be32 remote_id;
 	int id;
 

--- a/drivers/infiniband/core/mad.c
+++ b/drivers/infiniband/core/mad.c
@@ -1563,10 +1563,10 @@ static inline int rcv_has_same_gid(struct ib_mad_agent_private *mad_agent_priv,
 				   struct ib_mad_send_wr_private *wr,
 				   struct ib_mad_recv_wc *rwc )
 {
-	struct ib_ah_attr attr;
+	struct ib_ah_attr attr = {0};
 	u8 send_resp, rcv_resp;
 	union ib_gid sgid;
-	u8 lmc;
+	u8 lmc = 0;
 	//struct ib_device *device = mad_agent_priv->agent.device;
 	//u8 port_num = mad_agent_priv->agent.port_num;
 

--- a/include/lego/log2.h
+++ b/include/lego/log2.h
@@ -17,7 +17,8 @@
 #include <lego/types.h>
 #include <lego/bitops.h>
 
-__attribute__((const, noreturn)) int ____ilog2_NaN(void);
+//__attribute__((const, noreturn)) int ____ilog2_NaN(void);
+#define ____ilog2_NaN() (~0ULL)
 
 static inline __attribute__((const))
 int __ilog2_u32(u32 n)

--- a/init/calibrate.c
+++ b/init/calibrate.c
@@ -21,7 +21,7 @@ unsigned long loops_per_jiffy = (1<<12);
 
 void __init calibrate_delay(void)
 {
-	unsigned long lpj;
+	unsigned long lpj = 0;
 
 	if (lpj_fine) {
 		lpj = lpj_fine;

--- a/managers/processor/exec.c
+++ b/managers/processor/exec.c
@@ -425,7 +425,7 @@ int do_execve(const char __user *filename,
 {
 	int ret;
 	__u32 payload_size, reply_size;
-	unsigned long new_ip, new_sp;
+	unsigned long new_ip = 0, new_sp = 0;
 	struct pt_regs *regs = current_pt_regs();
 	void *payload, *reply;
 

--- a/managers/processor/wait.c
+++ b/managers/processor/wait.c
@@ -153,7 +153,7 @@ static int wait_task_zombie(struct wait_opts *wo, struct task_struct *p)
 		struct signal_struct *sig = p->signal;
 		struct signal_struct *psig = current->signal;
 		unsigned long maxrss;
-		cputime_t tgutime, tgstime;
+		cputime_t tgutime = 0, tgstime = 0;
 
 		/*
 		 * The resource counters for the group leader are in its
@@ -603,7 +603,7 @@ SYSCALL_DEFINE5(waitid, int, which, pid_t, upid, struct siginfo __user *,
 		infop, int, options, struct rusage __user *, ru)
 {
 	struct wait_opts wo;
-	pid_t pid;
+	pid_t pid = 0;
 	enum pid_type type;
 	long ret;
 
@@ -674,7 +674,7 @@ SYSCALL_DEFINE4(wait4, pid_t, upid, int __user *, stat_addr,
 		int, options, struct rusage __user *, ru)
 {
 	struct wait_opts wo;
-	pid_t pid;
+	pid_t pid = 0;
 	enum pid_type type;
 	long ret;
 

--- a/net/lego/fit_internal.c
+++ b/net/lego/fit_internal.c
@@ -2822,7 +2822,7 @@ int fit_send_message_sge(ppc *ctx, int connection_id, int type, void *addr,
 	struct ib_send_wr wr, *bad_wr = NULL;
 	struct ib_sge sge[2];
 	int ret;
-	int ne, i;
+	int ne, i = 0;
 	struct ib_wc wc[2];
 	struct ibapi_header msg_header;
 	void *msg_header_addr;


### PR DESCRIPTION
I fix the build error in the following environments.

- Linux 4.15.0 (Ubuntu 18.04)
- GCC 7.3

Please review my code.
The build error is caused by uninitiailized local values and undefined references.
Note that the modification of include/lego/log2.h may generate a build error in your environment.
