### PR TITLE
GSM and Multiple S components support

### DIFF
--- a/include/lego/rpc/struct_p2m.h
+++ b/include/lego/rpc/struct_p2m.h
@@ -101,6 +101,7 @@ struct p2m_read_write_payload {
 	u32	tgid;
 	char __user *buf;
 	int	uid;
+	__u32	storage_node;
 	char	filename[MAX_FILENAME_LENGTH];
 	int	flags;
 	ssize_t	len;

--- a/linux-modules/monitor/Makefile
+++ b/linux-modules/monitor/Makefile
@@ -2,6 +2,7 @@
 MONITORS := gmm
 MONITORS += gpm
 MONITORS += gum
+MONITORS += gsm
 MONITORS += gm_dispatcher
 
 # rules
@@ -20,6 +21,7 @@ install:
 	insmod $(shell pwd)/gmm/lego_gmm.ko && \
 	insmod $(shell pwd)/gpm/lego_gpm.ko && \
 	insmod $(shell pwd)/gum/lego_gum.ko && \
+	insmod $(shell pwd)/gsm/lego_gsm.ko && \
 	insmod $(shell pwd)/gm_dispatcher/lego_gm_dispatcher.ko
 
 .PHONY: all $(SUBDIRS) $(CLEAN_SUBDIRS) install

--- a/linux-modules/monitor/gm_dispatcher/Makefile
+++ b/linux-modules/monitor/gm_dispatcher/Makefile
@@ -6,6 +6,7 @@ ccflags-y += -I$(src)/../../../include
 KBUILD_EXTRA_SYMBOLS += $(shell pwd)/../../fit/Module.symvers
 KBUILD_EXTRA_SYMBOLS += $(shell pwd)/../gpm/Module.symvers
 KBUILD_EXTRA_SYMBOLS += $(shell pwd)/../gmm/Module.symvers
+KBUILD_EXTRA_SYMBOLS += $(shell pwd)/../gsm/Module.symvers
 export KBUILD_EXTRA_SYMBOLS
 
 # Targets

--- a/linux-modules/monitor/gm_dispatcher/lego_gm_dispatcher.c
+++ b/linux-modules/monitor/gm_dispatcher/lego_gm_dispatcher.c
@@ -17,6 +17,7 @@
 #include <common.h>
 #include <gmm.h>
 #include <gpm.h>
+#include <gsm.h>
 
 /* 
  * this module act as a linux module ib receiver and dispatcher,
@@ -68,6 +69,10 @@ static int req_dispatcher(void)
 
 	case M2MM_STATUS_REPORT:
 		handle_m2mm_status_report((void *)rcvbuf, desc);
+		break;
+
+	case P2GSM_COMMON:
+		handle_p2sm_alloc_nodes((int *)rcvbuf, desc);
 		break;
 
 	default:

--- a/linux-modules/monitor/gsm/Makefile
+++ b/linux-modules/monitor/gsm/Makefile
@@ -1,0 +1,15 @@
+obj-m := lego_gsm.o
+lego_gsm-y := core.o hlist.o handlers.o
+
+ccflags-y := -I$(src)/../include
+ccflags-y += -I$(src)/../../../include
+
+cflags += -g
+EXTRA_CFLAGS += -g
+KBUILD_EXTRA_SYMBOLS += $(shell pwd)/../../fit/Module.symvers
+export KBUILD_EXTRA_SYMBOLS
+
+all:
+	make -C /lib/modules/$(shell uname -r)/build M=$(shell pwd) modules
+clean:
+	rm -rf *.o *.ko *.mod.c .*.cmd *.markers *.order *.symvers .tmp_versions *~

--- a/linux-modules/monitor/gsm/core.c
+++ b/linux-modules/monitor/gsm/core.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2016-2017 Wuklab, Purdue University. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "gsm.h"
+#include <linux/string.h>
+#include <linux/kernel.h>
+#include <linux/slab.h>
+#include <linux/fs.h>
+#include <linux/module.h>
+#include <linux/sched.h>
+#include <linux/kthread.h>
+
+const char *log_fname = "/home/yilun/lego-gsm-log";
+static struct file *log;
+
+int global_storage_id[NUM_STORAGE_NODE];
+
+static void init_storage_lid(void)
+{
+	global_storage_id[0] = 2;
+	global_storage_id[1] = 4;
+}
+
+void log_vnode(struct lego_vnode_struct *mm_vnode, bool delete)
+{
+	struct raw_vnode_struct raw_vnode;
+	ssize_t ret;
+
+	if (IS_ERR_OR_NULL(log))
+		return;
+
+	raw_vnode.vid = mm_vnode->vid;
+	raw_vnode.sid = mm_vnode->storage_node_id;
+
+	if (delete)
+		raw_vnode.valid = false;
+	else
+		raw_vnode.valid = true;
+
+	ret = kernel_write(log, (char *) &raw_vnode, sizeof(raw_vnode), log->f_pos);
+
+	if (ret != sizeof(raw_vnode))
+		pr_warn("Fail to log vnode");
+}
+
+struct lego_vnode_struct *alloc_lego_vnode(int vid, int sid)
+{
+	struct lego_vnode_struct *mm_vnode;
+	mm_vnode = kmalloc(sizeof(*mm_vnode), GFP_KERNEL);
+	if (!mm_vnode)
+		return NULL;
+	
+	mm_vnode->vid = vid;
+	mm_vnode->storage_node_id = sid;
+	mm_vnode->pgcache_node_id = -1;
+
+	return mm_vnode;
+}
+
+static int __init lego_gsm_module_init(void)
+{
+
+	init_storage_lid();
+	log = filp_open(log_fname, O_RDWR | O_CREAT | O_APPEND, 0644);
+	if (!IS_ERR_OR_NULL(log))
+		reconstruct_hash_table(log);
+	
+	return 0;
+}
+
+static void __exit lego_gsm_module_exit(void)
+{
+	if (!IS_ERR_OR_NULL(log))
+		filp_close(log, NULL);
+
+	/* free hashtable */
+	clear_hash_table();
+	pr_info("Bye GSM!\n");
+	return;
+}
+
+MODULE_LICENSE("GPL");
+MODULE_AUTHOR("Yilun");
+module_init(lego_gsm_module_init);
+module_exit(lego_gsm_module_exit);

--- a/linux-modules/monitor/gsm/handlers.c
+++ b/linux-modules/monitor/gsm/handlers.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2016-2017 Wuklab, Purdue University. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "gsm.h"
+
+int handle_p2sm_alloc_nodes(int *payload, uintptr_t desc)
+{
+	int vid = *payload;
+	struct lego_vnode_struct *mm_vnode;
+	struct gsm2p_ret_struct res;
+	int ret = 0;
+
+	res.mid = -1;
+	res.sid = -1;
+
+	mm_vnode = ht_find_lego_vnode(vid);
+	if (!mm_vnode) {
+		mm_vnode = alloc_lego_vnode(vid, alloc_sid(vid));
+		if (unlikely(!mm_vnode)) {
+			ret = -ENOMEM;
+			goto reply;
+		}
+
+		ht_insert_lego_vnode(mm_vnode);
+	}
+	
+	res.sid = mm_vnode->storage_node_id;
+
+	if (mm_vnode->pgcache_node_id == -1) {
+		/* TODO:
+		 * should be determined by GMM
+		 * now always let mem node DEFAULT_MEM_HOMENODE as page cache node
+		 */
+		mm_vnode->pgcache_node_id = DEFAULT_MEM_HOMENODE;
+	}
+	res.mid = mm_vnode->pgcache_node_id;
+reply:
+	ibapi_reply_message(&res, sizeof(res), desc);
+	return ret;
+}
+EXPORT_SYMBOL(handle_p2sm_alloc_nodes);

--- a/linux-modules/monitor/gsm/hlist.c
+++ b/linux-modules/monitor/gsm/hlist.c
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2016-2017 Wuklab, Purdue University. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#include "gsm.h"
+#include <linux/string.h>
+#include <linux/slab.h>
+#include <linux/fs.h>
+#include <linux/hashtable.h>
+
+#define GSM_HASH_SHIFT		10
+
+static DEFINE_SPINLOCK(gsm_hash_lock);
+static DEFINE_HASHTABLE(gsm_hash, GSM_HASH_SHIFT);
+
+/* check before insert */
+int ht_insert_lego_vnode(struct lego_vnode_struct *mm_vnode)
+{
+	struct lego_vnode_struct *p;
+
+	if (IS_ERR_OR_NULL(mm_vnode))
+		return -EFAULT;
+
+	spin_lock(&gsm_hash_lock);
+	hash_for_each_possible(gsm_hash, p, hlink, mm_vnode->vid) {
+		if (unlikely(p->vid == mm_vnode->vid)) {
+			spin_unlock(&gsm_hash_lock);
+			return -EEXIST;
+		}
+	}
+	hash_add(gsm_hash, &mm_vnode->hlink, mm_vnode->vid);
+	log_vnode(mm_vnode, false);
+	spin_unlock(&gsm_hash_lock);
+
+	return 0;
+}
+
+/* remove from hashtable */
+int ht_remove_lego_vnode(struct lego_vnode_struct *mm_vnode)
+{
+	if (IS_ERR_OR_NULL(mm_vnode))
+		return -EINVAL;
+
+	spin_lock(&gsm_hash_lock);
+	hash_del(&mm_vnode->hlink);
+	log_vnode(mm_vnode, true);
+	kfree(mm_vnode);
+	spin_unlock(&gsm_hash_lock);
+	return 0;
+}
+
+/* find the vnode struct in hashtable */
+struct lego_vnode_struct *ht_find_lego_vnode(int vid)
+{
+	struct lego_vnode_struct *mm_vnode;
+
+	spin_lock(&gsm_hash_lock);
+	hash_for_each_possible(gsm_hash, mm_vnode, hlink, vid) {
+		if (likely(mm_vnode->vid == vid)) {
+			spin_unlock(&gsm_hash_lock);
+			return mm_vnode;
+		}
+	}
+	spin_unlock(&gsm_hash_lock);
+	return NULL;
+}
+
+int reconstruct_hash_table(struct file *log)
+{
+	size_t len_log, cur;
+
+	if (IS_ERR_OR_NULL(log)) {
+		pr_warn("No log file exist.\n");
+		return -ENOENT;
+	}
+
+	len_log = i_size_read(log->f_inode);
+	cur = 0;
+
+	while(cur != len_log) {
+		struct lego_vnode_struct *mm_vnode;
+		struct raw_vnode_struct raw_vnode;
+		size_t retlen;
+
+		retlen = kernel_read(log, cur, (char *) &raw_vnode, sizeof(raw_vnode));
+		if (unlikely(retlen != sizeof(raw_vnode)))
+			return -EIO;
+
+		if (!raw_vnode.valid) {
+			mm_vnode = ht_find_lego_vnode(raw_vnode.vid);
+			if (!mm_vnode) {
+				cur += sizeof(raw_vnode);
+				continue;
+			}
+			ht_remove_lego_vnode(mm_vnode);
+		} else {
+			mm_vnode = alloc_lego_vnode(raw_vnode.vid, raw_vnode.sid);
+			if (unlikely(!mm_vnode))
+				return -ENOMEM;
+			
+			pr_info("insert hashtable with vnode->(id: %d, sid: %d)\n",
+					mm_vnode->vid, mm_vnode->storage_node_id);
+			ht_insert_lego_vnode(mm_vnode);
+		}
+
+		cur += sizeof(raw_vnode);
+	}
+
+	return 0;
+
+}
+
+void clear_hash_table(void)
+{
+	int bkt;
+	struct lego_vnode_struct *mm_vnode;
+	struct hlist_node *tmp;
+
+	spin_lock(&gsm_hash_lock);
+	hash_for_each_safe(gsm_hash, bkt, tmp, mm_vnode, hlink) {
+		hash_del(&mm_vnode->hlink);
+
+		pr_info("free mm_vnode->(vid: %d, sid: %d)\n",
+			mm_vnode->vid, mm_vnode->storage_node_id);
+		kfree(mm_vnode);
+	}
+
+	spin_unlock(&gsm_hash_lock);
+
+	if (hash_empty(gsm_hash))
+		pr_info("Successfully free Hash Table.\n");
+}

--- a/linux-modules/monitor/include/gsm.h
+++ b/linux-modules/monitor/include/gsm.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2016-2017 Wuklab, Purdue University. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ */
+
+#ifndef __LEGO_GSM_
+#define __LEGO_GSM_
+
+#include <linux/hashtable.h>
+#include <asm/unistd.h>
+#include <common.h>
+
+#define NUM_STORAGE_NODE	2
+#define DEFAULT_MEM_HOMENODE	1
+extern int global_storage_id[NUM_STORAGE_NODE];
+
+#define alloc_s_node(x)		(x % NUM_STORAGE_NODE)
+#define alloc_sid(x)		(global_storage_id[alloc_s_node(x)])
+
+struct lego_vnode_struct {
+	int vid;
+	int pgcache_node_id;
+	int storage_node_id;
+
+	struct hlist_node hlink;
+};
+
+struct raw_vnode_struct {
+	int vid;
+	int sid;
+	bool valid;
+};
+
+struct gsm2p_ret_struct {
+	int mid;
+	int sid;
+};
+
+/* hlist.c */
+int ht_insert_lego_vnode(struct lego_vnode_struct *mm_vnode);
+int ht_remove_lego_vnode(struct lego_vnode_struct *mm_vnode);
+struct lego_vnode_struct *ht_find_lego_vnode(int vid);
+int reconstruct_hash_table(struct file *log);
+void clear_hash_table(void);
+
+/* core.c */
+struct lego_vnode_struct *alloc_lego_vnode(int vid, int sid);
+void log_vnode(struct lego_vnode_struct *mm_vnode, bool delete);
+
+/* handlers.c */
+int handle_p2sm_alloc_nodes(int *payload, uintptr_t desc);
+
+#endif /* __LEGO_GSM_ */

--- a/managers/Kconfig
+++ b/managers/Kconfig
@@ -74,8 +74,8 @@ config GSM
 if GSM
 config GSM_HOMENODE
 	int "GSM homenode ID"
-	depends on FIT_LOCAL_ID || FIT_NR_NODES
-endif #if GSM
+	depends on COMP_PROCESSOR || COMP_MEMORY
+endif # if GSM
 
 endmenu # General Manager Config/Debug
 

--- a/managers/processor/fs/default_f_ops.c
+++ b/managers/processor/fs/default_f_ops.c
@@ -109,6 +109,7 @@ static ssize_t p2m_read(struct file *f, char __user *buf, size_t count,
 	payload->flags = f->f_flags;
 	payload->len = count;
 	payload->offset = *off;
+	payload->storage_node = current_storage_home_node();
 
 	mem_node = current_pgcache_home_node();
 	retlen = ibapi_send_reply_imm(mem_node, msg, len_msg,
@@ -179,6 +180,7 @@ static ssize_t __p2m_write(struct file *f, const char __user *buf,
 	payload->uid = current_uid();
 	payload->flags = f->f_flags;
 	payload->len = count;
+	payload->storage_node = current_storage_home_node();
 
 	payload->offset = (*off);
 	strncpy(payload->filename, f->f_name, MAX_FILENAME_LENGTH);

--- a/managers/processor/monitor/Makefile
+++ b/managers/processor/monitor/Makefile
@@ -1,4 +1,4 @@
 obj-$(CONFIG_GPM) += gpm_handler.o
 obj-$(CONFIG_MONITOR_GMM) += gmm.o
-obj-$(CONFIG_MONITOR_GSM) += gsm.o
+obj-$(CONFIG_GSM) += gsm.o
 obj-$(CONFIG_MONITOR_GSM) += gpm.o

--- a/managers/processor/monitor/gsm.c
+++ b/managers/processor/monitor/gsm.c
@@ -10,6 +10,7 @@
 #include <lego/slab.h>
 #include <lego/fit_ibapi.h>
 #include <processor/processor.h>
+#include <lego/rpc/struct_p2gm.h>
 #include <lego/comp_common.h>
 
 #ifdef CONFIG_GSM
@@ -46,7 +47,9 @@ int get_info_from_gsm(int my_vnode_id)
 		return -EIO;
 	}
 
+#ifdef CONFIG_MEM_PAGE_CACHE
 	set_pgcache_home_node(current, retbuf.mid);
+#endif /* CONGIG_MEM_PAGE_CACHE */
 	set_storage_home_node(current, retbuf.sid);
 	kfree(p2gsm_msg);
 	return 0;


### PR DESCRIPTION
Done and tested:
        - global storage monitor (GSM)
        - P->GSM consult
        - P->M (page cache)->S  homenode for read/write
        - P->S homenode for other storage syscalls

Left:
        - P->M->S homenode for read/write (when page cache is not configured)
        - hook with memory-mapped files and distributed VMAs